### PR TITLE
[#156226677] Secure instance passwords (cleanup part)

### DIFF
--- a/jobs/elasticache-broker/spec
+++ b/jobs/elasticache-broker/spec
@@ -20,8 +20,6 @@ properties:
     default: "elasticache-broker"
   elasticache-broker.broker_password:
     description: "The password for basic auth between the Cloud Controller and the broker"
-  elasticache-broker.auth_token_seed:
-    description: "The common seed for generating authentication tokens for the ElastiCache clusters"
   elasticache-broker.cache_subnet_group_name:
     description: "The ElastiCache Subnet Group name where the ElastiCache clusters will be created"
   elasticache-broker.vpc_security_group_ids:

--- a/jobs/elasticache-broker/templates/config/config.json.erb
+++ b/jobs/elasticache-broker/templates/config/config.json.erb
@@ -2,7 +2,6 @@
   "broker_name": "<%= p('elasticache-broker.broker_name') %>",
   "username": "<%= p('elasticache-broker.broker_username') %>",
   "password": "<%= p('elasticache-broker.broker_password') %>",
-  "auth_token_seed": "<%= p('elasticache-broker.auth_token_seed') %>",
   "region": "<%= p('elasticache-broker.region') %>",
   "cache_subnet_group_name": "<%= p('elasticache-broker.cache_subnet_group_name') %>",
   "vpc_security_group_ids": <%= JSON.dump(p('elasticache-broker.vpc_security_group_ids')) %>,


### PR DESCRIPTION
## What

In https://github.com/alphagov/paas-elasticache-broker-boshrelease/pull/9 we started to generate and store auth tokens in Secrets Manager.

This PR removes the auth token seed parameter as we don't need it anymore.

For the broker changes please see https://github.com/alphagov/paas-elasticache-broker/pull/14

❗️ This PR contains a temporary commit which needs to be updated with the final elasticache-broker version

## How to review

Review as part of https://github.com/alphagov/paas-cf/pull/1320

## Who can review

Not @46bit or me.
