### PR TITLE
Add tls support

### DIFF
--- a/jobs/elasticache-broker/spec
+++ b/jobs/elasticache-broker/spec
@@ -39,3 +39,20 @@ properties:
   elasticache-broker.secrets_manager_path:
     description: "The path prefix used in AWS Secrets Manager to store Redis auth tokens. Trailing / characters are automatically removed"
     default: elasticache-broker
+  elasticache-broker.host:
+    description: "Broker Listen hostname or IP"
+    example: "0.0.0.0"
+  elasticache-broker.tls:
+    description: "Certificate and private key for TLS listener"
+    example: |
+      certificate: |
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+      private_key: |
+        -----BEGIN EXAMPLE RSA PRIVATE KEY-----
+        ...
+        -----END EXAMPLE RSA PRIVATE KEY-----

--- a/jobs/elasticache-broker/templates/config/config.json.erb
+++ b/jobs/elasticache-broker/templates/config/config.json.erb
@@ -1,5 +1,14 @@
 {
   "broker_name": "<%= p('elasticache-broker.broker_name') %>",
+<% if_p('elasticache-broker.host') do |host| -%>
+  "host": "<%= host %>",
+<% end -%>
+<% if_p('elasticache-broker.tls') do |tls| -%>
+  "tls": {
+    "certificate": "<%= tls.fetch("certificate").gsub(/\n/, '\\n') %>",
+    "private_key": "<%= tls.fetch("private_key").gsub(/\n/, '\\n') %>"
+  },
+<% end -%>
   "username": "<%= p('elasticache-broker.broker_username') %>",
   "password": "<%= p('elasticache-broker.broker_password') %>",
   "region": "<%= p('elasticache-broker.region') %>",


### PR DESCRIPTION
What
----

Add tls support to the elasticache broker.

Why
----

We need to ensure traffic is encrypted between the load balancer and the elasticache broker.